### PR TITLE
No 'retro' noise and tinder comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </div>
 <br>
 
-<h4>Using Kynosocial you can level up from Twitter, Reddit, and even Tinder. To a clean new platform unlike many others.</h4>
+<h4>Using Kynosocial you can level up from Twitter, Reddit, and especially Facebook (🤨). To a clean new platform unlike many others.</h4>
 
 ### Usage
 

--- a/css/themes.css
+++ b/css/themes.css
@@ -104,7 +104,7 @@
 	--border-radius: 5px;
 }
 .retro {
-	--root-background: hsl(0, 0%, 90%) url("/img/noise.png");
+	--root-background: hsl(0, 0%, 90%);
 	--global-filter: grayscale(100%);
 
 	--outer-color: black;


### PR DESCRIPTION
Read commits for more info.
- The noise is now gone. Retro should not try to look like paper, as old computer displays did not look like paper.
- The comparison of Kynosocial to Tinder was kind of odd, so I changed it to Facebook. FB is trying to do so many things, so Kynosocial will become better very rapidly if it's growth continues at the point it currently does.